### PR TITLE
add .gitignore, readme, license, update description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-name = "sdk"
+name = "arch_sdk"
 version = "0.1.0"
 edition = "2021"
+description = "A Rust library for providing data types, constants, RPC methods and helper functions for programs that run inside the Arch Virtual Machine."
+license = "MIT"
 
 [dependencies]
 arch_program = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [<img alt="crates.io" src="https://img.shields.io/crates/v/arch-sdk.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/arch-sdk)
 [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-arch_sdk?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/arch-sdk)
 
+A Rust library for providing data types, constants, RPC methods and helper functions for programs that run inside the Arch Virtual Machine.
+
+Includes utilities for signatures, preparing fees and managing transactions.
+
 #### License
 
 [MIT](https://github.com/Arch-Network/arch-sdk/blob/main/Cargo.toml#L6C1-L6C16)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# arch-sdk
+
+[<img alt="crates.io" src="https://img.shields.io/crates/v/arch-sdk.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/arch-sdk)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-arch_sdk?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/arch-sdk)
+
+#### License
+
+[MIT](https://github.com/Arch-Network/arch-sdk/blob/main/Cargo.toml#L6C1-L6C16)


### PR DESCRIPTION
**Currently in draft awaiting crates.io listing.**

This PR includes .gitignore file and README, as well as adds a license and updates the description within the `Cargo.toml`.

Closes: [devrel#17](https://github.com/Arch-Network/devrel/issues/17)