### PR TITLE
Allow the `solana` configuration flag

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -31,3 +31,6 @@ rand = "0.8.5"
 [dev-dependencies]
 proptest = "1.5.0"
 rand = "0.8.5"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }


### PR DESCRIPTION
The rust compiler does not recognize `solana` as a valid name for `cfg` purposes.

![Capture d’écran depuis 2025-05-22 11-03-11](https://github.com/user-attachments/assets/ba3acc06-4ca0-4da6-b3aa-22c0b4447cf9)

However, such a situation can be solved through the use of `unexpected_cfgs`, which is what this PR does.