### PR TITLE
 Fix typos in Rust source files

### DIFF
--- a/sdk/src/helper/bip322.rs
+++ b/sdk/src/helper/bip322.rs
@@ -43,12 +43,12 @@ pub fn sign_message_bip322(
                     create_message_signature_taproot(&to_spend, &to_sign, private_key)
                 }
                 _ => {
-                    panic!("unsuported address");
+                    panic!("unsupported address");
                 }
             }
         }
         None => {
-            panic!("unsuported address");
+            panic!("unsupported address");
         }
     };
 

--- a/test_sdk/src/helper.rs
+++ b/test_sdk/src/helper.rs
@@ -38,7 +38,7 @@ pub fn prepare_fees() -> String {
         BITCOIN_NODE_PASSWORD.to_string(),
     );
     let rpc =
-        Client::new(BITCOIN_NODE_ENDPOINT, userpass).expect("rpc shouldn not fail to be initiated");
+        Client::new(BITCOIN_NODE_ENDPOINT, userpass).expect("rpc should not fail to be initiated");
 
     let caller = CallerInfo::with_secret_key_file(CALLER_FILE_PATH)
         .expect("getting caller info should not fail");

--- a/test_sdk/src/instructions.rs
+++ b/test_sdk/src/instructions.rs
@@ -158,8 +158,8 @@ pub fn approve(
         BITCOIN_NETWORK,
     );
 
-    let processed_transactioins = send_transactions_and_wait(vec![transaction]);
-    assert_eq!(processed_transactioins[0].status, Status::Processed);
+    let processed_transactions = send_transactions_and_wait(vec![transaction]);
+    assert_eq!(processed_transactions[0].status, Status::Processed);
 }
 
 pub fn revoke(


### PR DESCRIPTION


### 🛠 Fix typos in Rust source files

This PR fixes several small spelling mistakes found across the codebase:

#### ✅ Changes:

* **`sdk/src/helper/bip322.rs`**

  * `unsuported` → `unsupported` (2 occurrences)
* **`test_sdk/src/helper.rs`**

  * `shouldn` → `should` (1 occurrence)
* **`test_sdk/src/instructions.rs`**

  * `transactioins` → `transactions` (1 occurrence)

