### PR TITLE
fix: restore publish-crates.yml workflow and root Cargo.toml deleted by sync

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,105 @@
+name: Publish Crates to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (validate only, do not publish)"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish all crates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-publish-
+
+      # ── Dry-run: validate all crates can compile and package ────────
+      - name: Build all workspace crates
+        if: inputs.dry_run == 'true'
+        run: cargo check --workspace
+
+      - name: Validate arch_program packaging
+        if: inputs.dry_run == 'true'
+        working-directory: program
+        run: cargo package --list
+
+      - name: Validate arch_sdk packaging
+        if: inputs.dry_run == 'true'
+        working-directory: sdk
+        run: cargo package --list
+
+      - name: Validate apl-token packaging
+        if: inputs.dry_run == 'true'
+        working-directory: token
+        run: cargo package --list
+
+      - name: Validate apl-associated-token-account packaging
+        if: inputs.dry_run == 'true'
+        working-directory: associated-token-account
+        run: cargo package --list
+
+      - name: Validate apl-token-metadata packaging
+        if: inputs.dry_run == 'true'
+        working-directory: token-metadata
+        run: cargo package --list
+
+      # ── Real publish: crates in dependency order with index waits ───
+      # Tier 1: arch_program (no internal deps)
+      - name: Publish arch_program
+        if: inputs.dry_run == 'false'
+        working-directory: program
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io to index arch_program
+        if: inputs.dry_run == 'false'
+        run: sleep 30
+
+      # Tier 2: arch_sdk & apl-token (depend on arch_program)
+      - name: Publish arch_sdk
+        if: inputs.dry_run == 'false'
+        working-directory: sdk
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish apl-token
+        if: inputs.dry_run == 'false'
+        working-directory: token
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io to index tier-2 crates
+        if: inputs.dry_run == 'false'
+        run: sleep 30
+
+      # Tier 3: crates that depend on apl-token
+      - name: Publish apl-associated-token-account
+        if: inputs.dry_run == 'false'
+        working-directory: associated-token-account
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish apl-token-metadata
+        if: inputs.dry_run == 'false'
+        working-directory: token-metadata
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+  "program",
+  "sdk",
+  "token",
+  "associated-token-account",
+  "token-metadata",
+]
+resolver = "2"
+
+[workspace.dependencies]
+arch_program = { path = "program", version = "0.6.0" }
+apl-token = { path = "token", version = "0.6.0", features = ["no-entrypoint"] }
+titan-types-core = "1.3.3"


### PR DESCRIPTION
## Summary

- Restores `.github/workflows/publish-crates.yml` and root `Cargo.toml` which were accidentally deleted by the sync-sdk workflow from arch-network. The workflow was wiping all non-`.git` files before copying the synced crate directories, which destroyed arch-sdk-specific configuration.
- The upstream workflow has been fixed in [arch-network PR #2067](https://github.com/Arch-Network/arch-network/pull/2067) to only remove the specific directories it syncs (`sdk/`, `program/`, `token/`, `associated-token-account/`, `token-metadata/`), preventing this from happening again.

## Test plan

- [ ] Verify `cargo check --workspace` passes after merge
- [ ] Verify the publish-crates workflow appears in the Actions tab with manual dispatch trigger
- [ ] After arch-network PR #2067 is merged, trigger a sync and confirm these files survive

Made with [Cursor](https://cursor.com)