### PR TITLE
fix: add patch.crates-io so cargo check --workspace works before publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ resolver = "2"
 arch_program = { path = "program", version = "0.6.0" }
 apl-token = { path = "token", version = "0.6.0", features = ["no-entrypoint"] }
 titan-types-core = "1.3.3"
+
+# Redirect crates.io lookups to local paths so cargo check --workspace
+# works before new versions are published to crates.io.
+[patch.crates-io]
+arch_program = { path = "program" }
+apl-token = { path = "token" }


### PR DESCRIPTION
## Summary

- The sync workflow from arch-network converts inter-crate path dependencies to version-only deps (e.g. `arch_program = "0.6.1"`). When a new version is synced, `cargo check --workspace` in the publish-crates dry-run fails because those versions don't exist on crates.io yet.
- Adds a `[patch.crates-io]` section to the root `Cargo.toml` that redirects `arch_program` and `apl-token` lookups to their local paths. This lets `cargo check --workspace` resolve inter-crate deps locally during dry-run validation, while `cargo publish` continues to work normally (it ignores `[patch]` sections).

## Test plan

- [ ] Trigger the publish-crates workflow with `dry_run: true` and verify `cargo check --workspace` passes
- [ ] Verify the patch doesn't interfere with the real publish flow (`dry_run: false`)

Made with [Cursor](https://cursor.com)