### PR TITLE
ci(publish-crates): always publish on push to main

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -4,23 +4,9 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Validate packaging only; do not publish to crates.io"
-        type: choice
-        options:
-          - "true"
-          - "false"
-        default: "true"
 
 env:
   CARGO_TERM_COLOR: always
-  # Effective dry-run flag.
-  # - On workflow_dispatch: use the user-selected input.
-  # - On push to main: default to a real publish (dry_run=false), matching the
-  #   workflow's purpose of publishing crates when changes land on main.
-  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
 
 jobs:
   publish:
@@ -44,69 +30,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-publish-
 
-      # ── Dry-run: validate all crates can compile and package ────────
-      - name: Build all workspace crates
-        if: env.DRY_RUN == 'true'
-        run: cargo check --workspace
-
-      - name: Validate arch_program packaging
-        if: env.DRY_RUN == 'true'
-        working-directory: program
-        run: cargo package --list
-
-      - name: Validate arch_sdk packaging
-        if: env.DRY_RUN == 'true'
-        working-directory: sdk
-        run: cargo package --list
-
-      - name: Validate apl-token packaging
-        if: env.DRY_RUN == 'true'
-        working-directory: token
-        run: cargo package --list
-
-      - name: Validate apl-associated-token-account packaging
-        if: env.DRY_RUN == 'true'
-        working-directory: associated-token-account
-        run: cargo package --list
-
-      - name: Validate apl-token-metadata packaging
-        if: env.DRY_RUN == 'true'
-        working-directory: token-metadata
-        run: cargo package --list
-
-      # ── Real publish: crates in dependency order with index waits ───
+      # ── Publish crates in dependency order with index waits ─────────
       # Tier 1: arch_program (no internal deps)
       - name: Publish arch_program
-        if: env.DRY_RUN == 'false'
         working-directory: program
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait for crates.io to index arch_program
-        if: env.DRY_RUN == 'false'
         run: sleep 30
 
       # Tier 2: arch_sdk & apl-token (depend on arch_program)
       - name: Publish arch_sdk
-        if: env.DRY_RUN == 'false'
         working-directory: sdk
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish apl-token
-        if: env.DRY_RUN == 'false'
         working-directory: token
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait for crates.io to index tier-2 crates
-        if: env.DRY_RUN == 'false'
         run: sleep 30
 
       # Tier 3: crates that depend on apl-token
       - name: Publish apl-associated-token-account
-        if: env.DRY_RUN == 'false'
         working-directory: associated-token-account
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish apl-token-metadata
-        if: env.DRY_RUN == 'false'
         working-directory: token-metadata
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -4,9 +4,23 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate packaging only; do not publish to crates.io"
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
 
 env:
   CARGO_TERM_COLOR: always
+  # Effective dry-run flag.
+  # - On workflow_dispatch: use the user-selected input.
+  # - On push to main: default to a real publish (dry_run=false), matching the
+  #   workflow's purpose of publishing crates when changes land on main.
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
 
 jobs:
   publish:
@@ -32,67 +46,67 @@ jobs:
 
       # ── Dry-run: validate all crates can compile and package ────────
       - name: Build all workspace crates
-        if: inputs.dry_run == 'true'
+        if: env.DRY_RUN == 'true'
         run: cargo check --workspace
 
       - name: Validate arch_program packaging
-        if: inputs.dry_run == 'true'
+        if: env.DRY_RUN == 'true'
         working-directory: program
         run: cargo package --list
 
       - name: Validate arch_sdk packaging
-        if: inputs.dry_run == 'true'
+        if: env.DRY_RUN == 'true'
         working-directory: sdk
         run: cargo package --list
 
       - name: Validate apl-token packaging
-        if: inputs.dry_run == 'true'
+        if: env.DRY_RUN == 'true'
         working-directory: token
         run: cargo package --list
 
       - name: Validate apl-associated-token-account packaging
-        if: inputs.dry_run == 'true'
+        if: env.DRY_RUN == 'true'
         working-directory: associated-token-account
         run: cargo package --list
 
       - name: Validate apl-token-metadata packaging
-        if: inputs.dry_run == 'true'
+        if: env.DRY_RUN == 'true'
         working-directory: token-metadata
         run: cargo package --list
 
       # ── Real publish: crates in dependency order with index waits ───
       # Tier 1: arch_program (no internal deps)
       - name: Publish arch_program
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         working-directory: program
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait for crates.io to index arch_program
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         run: sleep 30
 
       # Tier 2: arch_sdk & apl-token (depend on arch_program)
       - name: Publish arch_sdk
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         working-directory: sdk
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish apl-token
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         working-directory: token
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait for crates.io to index tier-2 crates
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         run: sleep 30
 
       # Tier 3: crates that depend on apl-token
       - name: Publish apl-associated-token-account
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         working-directory: associated-token-account
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish apl-token-metadata
-        if: inputs.dry_run == 'false'
+        if: env.DRY_RUN == 'false'
         working-directory: token-metadata
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why the checks were skipped

In run [24993120255](https://github.com/Arch-Network/arch-sdk/actions/runs/24993120255/job/73183316356), every build/validate/publish step in `Publish all crates` was marked **skipped** while the job reported success. Only `Checkout`, `Install Rust toolchain`, and `Cache cargo registry & build` actually ran.

Root cause: `.github/workflows/publish-crates.yml` gated every meaningful step on `inputs.dry_run == 'true'` or `inputs.dry_run == 'false'`, but the workflow only declared a `push` trigger:

```yaml
on:
  push:
    branches:
      - main
```

There was no `workflow_dispatch` block defining a `dry_run` input, so on push events `inputs.dry_run` was unset (null). Null equals neither the string `'true'` nor `'false'`, so every step's `if:` evaluated to false and was skipped. GitHub still reports the overall job as `success` when only setup/cache steps run, which is why the run looked green despite nothing actually happening.

## Fix

The workflow's sole purpose is to publish crates when changes land on `main`, so:

- Drop the `inputs.dry_run` gating entirely; no `workflow_dispatch` trigger is added.
- Remove the dry-run-only validation steps (`cargo check --workspace` and the `cargo package --list` calls). The actual `cargo publish` steps will fail loudly if a crate cannot be packaged or built, so the separate validation steps were redundant for a publish-on-push workflow.
- Keep the existing dependency-ordered publish flow with index-wait sleeps:
  - Tier 1: `arch_program`
  - sleep 30s
  - Tier 2: `arch_sdk`, `apl-token`
  - sleep 30s
  - Tier 3: `apl-associated-token-account`, `apl-token-metadata`

## Behavior after this change

Every push to `main` runs all `cargo publish` steps unconditionally, using `secrets.CARGO_REGISTRY_TOKEN`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03070d91-dc45-4a95-8eb8-347f26fcfeb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03070d91-dc45-4a95-8eb8-347f26fcfeb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

